### PR TITLE
 Reformat stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,20 +4,16 @@ resolver: lts-11.13
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
-- location:
-    git: https://github.com/haskell-distributed/distributed-process.git
-    commit: d91a88f70c2cb6a6511283c5720bd9950fc3c55a
-  extra-dep: true
-- location:
-    git: https://github.com/haskell-distributed/distributed-process-systest.git
-    commit: b4a6b646adb6c81725ddac4babcfc21b86944d98
-  extra-dep: true
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
 - rematch-0.2.0.0
 - exceptions-0.10.0
 - network-transport-tcp-0.6.0 # works locally without it but doesn't pass CI
+- git: https://github.com/haskell-distributed/distributed-process.git
+  commit: d91a88f70c2cb6a6511283c5720bd9950fc3c55a
+- git: https://github.com/haskell-distributed/distributed-process-systest.git
+  commit: b4a6b646adb6c81725ddac4babcfc21b86944d98
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This fixes the `stack build` parsing error. However, there seems to be a GHC error when calling `stack build`:
```
ghc: panic! (the 'impossible' happened)
  (GHC version 8.2.2 for x86_64-apple-darwin):
	Prelude.chr: bad argument: 1543503875

Please report this as a GHC bug:  http://www.haskell.org/ghc/reportabug


--  While building simple Setup.hs (scroll up to its section to see the error) using:
      /Users/cannon/.stack/programs/x86_64-osx/ghc-8.2.2/bin/ghc-8.2.2 -rtsopts -threaded -clear-package-db -global-package-db -hide-all-packages -package base -main-is StackSetupShim.mainOverride -package Cabal-2.0.1.0 /Users/cannon/.stack/setup-exe-src/setup-mPHDZzAJ.hs /Users/cannon/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs -o /Users/cannon/.stack/setup-exe-cache/x86_64-osx/tmp-Cabal-simple_mPHDZzAJ_2.0.1.0_ghc-8.2.2
    Process exited with code: ExitFailure 1
```
Note that my Mac has an Intel CPU.